### PR TITLE
test(exceptions/simple): udpate expected error message

### DIFF
--- a/tests/exceptions/simple.rs
+++ b/tests/exceptions/simple.rs
@@ -9,9 +9,10 @@ fn try_catch_finally_throwable() -> Result<(), Box<dyn std::error::Error>> {
     // contains both an assert.failure() and an assert.success(),
     // so that failure() can be simply removed when all features
     // are implemented
-    cmd.assert()
-        .failure()
-        .stderr(predicate::str::contains("Unknown Attribute StackMapTable"));
+    cmd.assert().failure().stderr(predicate::str::contains(
+        "New(Rc<dyn Any>), \
+needs information on how to resolve at execution time",
+    ));
     // cmd.assert()
     //     .success()
     //     .stdout(predicate::str::contains("caught e:\nOops\nanyway\n"));


### PR DESCRIPTION
Needed since the control flow implementation
added preliminary support of the StackMapTable
attribute.