### PR TITLE
refactor(opcode): introduce symbolic references

### DIFF
--- a/src/bin/cmjava.rs
+++ b/src/bin/cmjava.rs
@@ -119,7 +119,10 @@ fn main() -> anyhow::Result<()> {
     let main = &bytecode_classes
         .last()
         .unwrap()
-        .get_method("main", main_descriptor)
+        .get_method(
+            "main",
+            (main_descriptor.0.as_ref(), main_descriptor.1.as_ref()),
+        )
         .unwrap()
         .code;
     let main = if let MethodCode::Bytecode(code) = main {

--- a/src/class.rs
+++ b/src/class.rs
@@ -71,14 +71,14 @@ impl dyn Class {
     pub fn get_method(
         &self,
         method_name: &str,
-        method_descriptor: (Vec<ArgumentKind>, Option<ArgumentKind>),
+        method_descriptor: (&[ArgumentKind], Option<&ArgumentKind>),
     ) -> Option<Rc<Method>> {
         self.methods()
             .iter()
             .find(|element| {
                 element.name == method_name
                     && element.parameters == method_descriptor.0
-                    && element.return_type == method_descriptor.1
+                    && element.return_type.as_ref() == method_descriptor.1
             })
             .cloned()
     }

--- a/tests/static_functions.rs
+++ b/tests/static_functions.rs
@@ -11,7 +11,7 @@ fn static_functions() -> Result<(), Box<dyn std::error::Error>> {
     // are implemented
     // NOTE: make sure to unindent the strings when uncommenting!
     cmd.assert().failure().stderr(predicate::str::contains(
-        "Class with name  org/cmjava2023/Main exists",
+        "Missing OpCode implementation for: InvokeStatic",
     ));
     // prints '[I@a92b32a' (i.e. @<some memory address)
     // since memory address is unpredictable,


### PR DESCRIPTION
Op codes like `new`, `invoke{static,special,virtual}`, etc may refer to the class being currently parsed.
Until now, op codes contained fully resolved references to the class/method/field they refer to.
This is in conflict with the current single-pass parsing architecture, since the class object to create a reference to does not exist yet when parsing the op codes.

In order to be able to keep the single-pass architecture, this commit uses symbolic references (i.e. strings) instead of resolved references,
which are then resolved at runtime,
in cases where the op code might refer to the class currently being parsed.

The effect of this change can be seen by the different error raised by the static_functions test.

closes #85 
depends on #86 re the failing exceptions::simple test